### PR TITLE
Boilerplates deploying wasm updates

### DIFF
--- a/docusaurus/docs/2d-charts/chart-modifier-api/custom-modifiers/detecting-clicks-on-chart-parts/index.md
+++ b/docusaurus/docs/2d-charts/chart-modifier-api/custom-modifiers/detecting-clicks-on-chart-parts/index.md
@@ -40,4 +40,4 @@ Try the above code with the following test harness:
     ```
 </CodeSnippetBlock>
 
-Find the full code sample for detecting clicks or mouse-over chart parts at [github.com/ABTSoftware/SciChart.JS.Examples/tree/dev\_v2.x/Sandbox/DocumentationSnippets/ChartModifierAPI](https://github.com/ABTSoftware/SciChart.JS.Examples/tree/dev_v2.x/Sandbox/DocumentationSnippets/ChartModifierAPI/src)
+Find the full code sample for detecting clicks or mouse-over chart parts at [github.com/ABTSoftware/SciChart.JS.Examples/tree/master/Sandbox/DocumentationSnippets/ChartModifierAPI](https://github.com/ABTSoftware/SciChart.JS.Examples/tree/master/Sandbox/DocumentationSnippets/ChartModifierAPI)

--- a/docusaurus/docs/2d-charts/surface/deploying-wasm/index.md
+++ b/docusaurus/docs/2d-charts/surface/deploying-wasm/index.md
@@ -13,22 +13,34 @@ If you receive an error message when running your app, you may not have deployed
 
 ### Option 1: Package Wasm & Data Files with Webpack (or similar) 
 
-In our tutorials and boilerplate examples we show you how to package the Wasm & Data files to load them in a variety of JavaScript frameworks. Find the links to setting up a JavaScript project below:
+In our tutorials and boilerplate examples we show you how to package the Wasm files to load them in a variety of JavaScript frameworks. Find the links to setting up a JavaScript project below:
 
-| JS Project Framework             | Boilerplate Project or Setup Instructions |
-|----------------------------------|-------------------------------------------|
-| npm / webpack                    | [Tutorial - Setting up a project with Webpack](/get-started/tutorials-js-npm-webpack/tutorial-01-setting-up-npm-project-with-scichart-js) |
-| Vanilla Javascript CDN (no npm, webpack) | [Tutorial - Including index.min.js and wasm files using CDN](/get-started/tutorials-cdn/tutorial-01-using-cdn) |
+| JS Project Framework                         | Boilerplate Project or Setup Instructions |
+|----------------------------------------------|-------------------------------------------|
+| npm / webpack                                | [Tutorial - Setting up a project with Webpack](/get-started/tutorials-js-npm-webpack/tutorial-01-setting-up-npm-project-with-scichart-js) |
+| Vanilla Javascript CDN (no npm, webpack)     | [Tutorial - Including index.min.js and wasm files using CDN](/get-started/tutorials-cdn/tutorial-01-using-cdn) |
 | Vanilla Javascript offline (no npm, webpack) | [Tutorial - Including index.min.js and wasm files offline](/get-started/tutorials-cdn/tutorial-02-offline) |
-| npm / webpack / react            | [code sample](https://github.com/ABTSoftware/SciChart.JS.Examples/tree/master/Sandbox/demo-react-scichart) |
-| vue.js                           | [code sample](https://github.com/ABTSoftware/SciChart.JS.Examples/tree/master/Sandbox/demo-vue-scichart) |
-| nextjs                           | [code sample](https://github.com/ABTSoftware/SciChart.JS.Examples/tree/master/Sandbox/demo-nextjs) |
-| Angular                          | [code sample](https://github.com/ABTSoftware/SciChart.JS.Examples/tree/master/Sandbox/demo-angular-scichart) |
-| blazor via JS Interop            | [code sample](https://github.com/ABTSoftware/SciChart.JS.Examples/tree/master/Sandbox/demo-blazor) |
-| Electron                         | [code sample](https://github.com/ABTSoftware/SciChart.JS.Examples/tree/master/Sandbox/scichart-electron-demo) |
+| React (scichart-react)                       | [code sample](https://github.com/ABTSoftware/SciChart.JS.Examples/tree/master/BoilerPlates/scichart-react) |
+| vue.js                                       | [code sample](https://github.com/ABTSoftware/SciChart.JS.Examples/tree/master/BoilerPlates/vue) |
+| svelte-vite                                  | [code sample](https://github.com/ABTSoftware/SciChart.JS.Examples/tree/master/BoilerPlates/svelte-vite) |
+| svelte-rollup                                | [code sample](https://github.com/ABTSoftware/SciChart.JS.Examples/tree/master/BoilerPlates/svelte-rollup) |
+| react-vite                                   | [code sample](https://github.com/ABTSoftware/SciChart.JS.Examples/tree/master/BoilerPlates/react-vite) |
+| nextjs                                       | [code sample](https://github.com/ABTSoftware/SciChart.JS.Examples/tree/master/BoilerPlates/next) |
+| Nuxt.js                                      | [code sample](https://github.com/ABTSoftware/SciChart.JS.Examples/tree/master/BoilerPlates/nuxt) |
+| Angular                                      | [code sample](https://github.com/ABTSoftware/SciChart.JS.Examples/tree/master/BoilerPlates/angular) |
+| Angular (scichart-angular)                   | [code sample](https://github.com/ABTSoftware/SciChart.JS.Examples/tree/master/BoilerPlates/scichart-angular) |
+| blazor via JS Interop                        | [code sample](https://github.com/ABTSoftware/SciChart.JS.Examples/tree/master/BoilerPlates/blazor) |
+| Electron                                     | [code sample](https://github.com/ABTSoftware/SciChart.JS.Examples/tree/master/BoilerPlates/electron) |
+| Tauri React Vite                             | [code sample](https://github.com/ABTSoftware/SciChart.JS.Examples/tree/master/BoilerPlates/tauri-vite-react) |
+| Tauri Javascript Vite                        | [code sample](https://github.com/ABTSoftware/SciChart.JS.Examples/tree/master/BoilerPlates/tauri-vite-vanilla) |
+| Web components                               | [code sample](https://github.com/ABTSoftware/SciChart.JS.Examples/tree/master/BoilerPlates/web-components) |
 
+:::info
+The above projects have been updated for SciChart.js v4, which has only a *.wasm file to serve.
+SciChart.js v3.x had *.wasm and *.data files. For older versions of SciChart, see the boilerplates folder in the [dev 3.5](https://github.com/ABTSoftware/SciChart.JS.Examples/tree/dev_v3.5/BoilerPlates) branch.
+:::
 :::tip
-See more boilerplate examples for JavaScript frameworks at our Github repository: [github.com/abtsoftware/scichart.js.examples](https://github.com/ABTSoftware/SciChart.JS.Examples/tree/master/Sandbox) under the Sandbox folder  
+See more boilerplate examples for JavaScript frameworks at our Github repository: [github.com/abtsoftware/scichart.js.examples](https://github.com/ABTSoftware/SciChart.JS.Examples/tree/master/Sandbox) under the Boilerplates folder  
 :::
 
 ### Option 2: Load Wasm from URL with SciChartSurface.configure() or useWasmFromCDN()

--- a/docusaurus/docs/2d-charts/surface/deploying-wasm/index.md
+++ b/docusaurus/docs/2d-charts/surface/deploying-wasm/index.md
@@ -13,7 +13,8 @@ If you receive an error message when running your app, you may not have deployed
 
 ### Option 1: Package Wasm & Data Files with Webpack (or similar) 
 
-In our tutorials and boilerplate examples we show you how to package the Wasm files to load them in a variety of JavaScript frameworks. Find the links to setting up a JavaScript project below:
+In our tutorials and boilerplate examples we show you how to package the Wasm files to load them in a variety of JavaScript frameworks including React, Angular, Vue, Vite, Electron, Tauri, Svelte, Blazor, Next, Nuxt and more.
+Find the links to setting up a JavaScript project below:
 
 | JS Project Framework                         | Boilerplate Project or Setup Instructions |
 |----------------------------------------------|-------------------------------------------|

--- a/docusaurus/docs/user-manual/online-resources-and-help/index.md
+++ b/docusaurus/docs/user-manual/online-resources-and-help/index.md
@@ -19,31 +19,33 @@ Are you new to SciChart? Check out our most popular pages to get started below:
 * [3D charts Basics](/3d-charts/scichart-3d-basics/scichart-3d-basics-overview)
 :::
 
-There are several online reosurces to help you get the best out of SciChart.js JavaScript Charts. These can be found at the following locations:
+There are several online resources to help you get the best out of SciChart.js JavaScript Charts. These can be found at the following locations:
 
 1.  Getting started guide at [www.scichart.com/getting-started-with-scichart-js](https://www.scichart.com/getting-started/scichart-javascript).
     * The [Getting Started with SciChart.js page](https://www.scichart.com/getting-started/scichart-javascript) contains a full guide on how to download SciChart.js, get started and setup new projects in React, Angular, Vue, Electron or vanilla JS
     * Where to get SciChart.js from npm, and JSDelivr CDN
     * Notes on the Community Licensing and commercial licensing
-3.  SciChart.js forums at [www.scichart.com/questions-js](https://www.scichart.com/questions/categories/js)
-4.  API Documentation at [https://www.scichart.com/documentation/js/v4/typedoc/index.html:blue_book:](https://www.scichart.com/documentation/js/v4/typedoc/index.html)
-5.  Support tickets (licensed customers only) at [https://support.scichart.com](https://support.scichart.com)    
-6.  The SciChart.js Online Demo at [https://www.scichart.com/demo](https://www.scichart.com/demo)
-7.  Source code for Online Demo at [https://github.com/ABTSoftware/SciChart.JS.Examples/tree/master/Examples](https://github.com/ABTSoftware/SciChart.JS.Examples/tree/master/Examples)
+2. SciChart.js forums at [www.scichart.com/questions-js](https://www.scichart.com/questions/categories/js)
+3.  API Documentation at [https://www.scichart.com/documentation/js/v4/typedoc/index.html:blue_book:](https://www.scichart.com/documentation/js/v4/typedoc/index.html)
+4.  Support tickets (licensed customers only) at [https://support.scichart.com](https://support.scichart.com)
+5. Free AI Assistant at https://chat.scichart.com
+6. The SciChart.js Online Demo with ~500 JavaScript, React and Angular demos at [https://www.scichart.com/demo](https://www.scichart.com/demo)
+7. Source code for Online JavaScript, React, Angular Demos at [https://github.com/ABTSoftware/SciChart.JS.Examples/tree/master/Examples](https://github.com/ABTSoftware/SciChart.JS.Examples/tree/master/Examples)
 8. Source code for tutorials [https://github.com/ABTSoftware/SciChart.JS.Examples/tree/master/Tutorials](https://github.com/ABTSoftware/SciChart.JS.Examples/tree/master/Tutorials)
-9. Source code for examples [https://github.com/ABTSoftware/SciChart.JS.Examples/tree/master/Sandbox](https://github.com/ABTSoftware/SciChart.JS.Examples/tree/master/Sandbox)
-    - [React Typescript Demo](https://github.com/ABTSoftware/SciChart.JS.Examples/tree/master/Sandbox/demo-react-typescript)
-    - [Vue Demo](https://github.com/ABTSoftware/SciChart.JS.Examples/tree/master/Sandbox/demo-vue-scichart)
-    - [Angular Demo](https://github.com/ABTSoftware/SciChart.JS.Examples/tree/master/Sandbox/demo-angular-scichart)
+9. Source code for framework boilerplate examples [https://github.com/ABTSoftware/SciChart.JS.Examples/tree/master/Boilerplates](https://github.com/ABTSoftware/SciChart.JS.Examples/tree/master/Boilerplates)
+    - [React Typescript Demo](https://github.com/ABTSoftware/SciChart.JS.Examples/tree/master/BoilerPlates/react-typescript)
+    - [Vue Demo](https://github.com/ABTSoftware/SciChart.JS.Examples/tree/master/BoilerPlates/vue)
+    - [Angular Demo](https://github.com/ABTSoftware/SciChart.JS.Examples/tree/master/BoilerPlates/scichart-angular)
     - [Webpack Typescript Demo](https://github.com/ABTSoftware/SciChart.JS.Examples/tree/master/Sandbox/demo-webpack-typescript)
-    - [Electron Demo](https://github.com/ABTSoftware/SciChart.JS.Examples/tree/master/Sandbox/scichart-electron-demo)
-    - [Blazor Demo](https://github.com/ABTSoftware/SciChart.JS.Examples/tree/master/Sandbox/demo-blazor)
+    - [Electron Demo](https://github.com/ABTSoftware/SciChart.JS.Examples/tree/master/BoilerPlates/electron)
+    - [Blazor Demo](https://github.com/ABTSoftware/SciChart.JS.Examples/tree/master/BoilerPlates/blazor)
     - [Browser Global Module Demo](https://github.com/ABTSoftware/SciChart.JS.Examples/tree/master/Sandbox/demo-browser-global-module)
     - [Create React App Demo](https://github.com/ABTSoftware/SciChart.JS.Examples/tree/master/Sandbox/demo-create-react-app-scichart)
-    - [Next.js Demo](https://github.com/ABTSoftware/SciChart.JS.Examples/tree/master/Sandbox/demo-nextjs)
-    - [Nuxt.js Demo](https://github.com/ABTSoftware/SciChart.JS.Examples/tree/master/Sandbox/demo-nuxtjs)
+    - [Next.js Demo](https://github.com/ABTSoftware/SciChart.JS.Examples/tree/master/BoilerPlates/next)
+    - [Nuxt.js Demo](https://github.com/ABTSoftware/SciChart.JS.Examples/tree/master/BoilerPlates/nuxt)
+    - [React Vite Demo](https://github.com/ABTSoftware/SciChart.JS.Examples/tree/master/BoilerPlates/react-vite)
 10. Source code for different customer examples [https://github.com/ABTSoftware/SciChart.JS.Examples/tree/master/Sandbox/CustomerExamples](https://github.com/ABTSoftware/SciChart.JS.Examples/tree/master/Sandbox/CustomerExamples)
-14. Licensing Demos
+11. Advanced Licensing (OEM / Server side licensing) Demos
     - [.Net Server Side Licensing Demo](https://github.com/abtsoftware/SciChart.JS.Examples/tree/master/AdvancedLicensing/dotnet-server-licensing)
     - [Node.js Server Side Licensing Demo](https://github.com/ABTSoftware/SciChart.JS.Examples/tree/master/AdvancedLicensing/nodejs-server-licensing)
-https://github.com/ABTSoftware/SciChart.JS.Examples/tree/master/Sandbox
+    - [C++ Licensing components for any server environment](https://github.com/ABTSoftware/SciChart.JS.Examples/tree/master/AdvancedLicensing/SciChartLicenseServer)


### PR DESCRIPTION
Boilerplates were being linked to /Sandbox/ folder in JS docs here:
https://www.scichart.com/documentation/js/v4/2d-charts/surface/deploying-wasm/

Have updated to https://github.com/ABTSoftware/SciChart.JS.Examples/tree/master/BoilerPlates/*